### PR TITLE
fix the cargo install of bindgen utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $ cargo install bpf-linker
 Finally, `bindgen` will need to be installed for `C` code bindings in Rust:
 
 ```console
-$ cargo install bindgen
+$ cargo install bindgen-cli
 ```
 
 ## Scaffolding our project


### PR DESCRIPTION
Reference: https://rust-lang.github.io/rust-bindgen/command-line-usage.html
```
$ cargo install bindgen-cli
```