### PR TITLE
was facing result type compilation error

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .context("failed to attach the XDP program with default flags - try changing XdpFlags::default() to XdpFlags::SKB_MODE")?;
 
     let mut backends: HashMap<_, u16, BackendPorts> =
-        HashMap::try_from(bpf.map_mut("BACKEND_PORTS")?)?;
+        HashMap::try_from(bpf.map_mut("BACKEND_PORTS").ok_or(anyhow::anyhow!("Failed to get BACKEND_PORTS"))?)?;
 
     let mut ports: [u16; 4] = [0; 4];
     ports[0] = 9876;


### PR DESCRIPTION
Hi,

While going through the blog post, I was facing the following compilation error in the part to "load the BPF map with data the XDP program can use to route traffic".

I've used the ok_or method to provide an error compatible with Result<(), _> and the anyhow crate to create a generic error message using anyhow::anyhow!.

Let me know if this makes sense or if I missed anything while going through it.

Thanks!

```
error[E0277]: the `?` operator can only be used on `Result`s, not `Option`s, in an async block that returns `Result`
  --> demo/src/main.rs:45:55
   |
17 | #[tokio::main]
   | -------------- this function returns a `Result`
...
45 |         HashMap::try_from(bpf.map_mut("BACKEND_PORTS")?)?;
   |                                                       ^ use `.ok_or(...)?` to provide an error compatible with `Result<(), _>`
   |
   = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<(), _>`
   = help: the following other types implement trait `FromResidual<R>`:
             <Result<T, F> as FromResidual<Result<Infallible, E>>>
             <Result<T, F> as FromResidual<Yeet<E>>>
```