### PR TITLE
Backend ports hashmap error

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .context("failed to attach the XDP program with default flags - try changing XdpFlags::default() to XdpFlags::SKB_MODE")?;
 
     let mut backends: HashMap<_, u16, BackendPorts> =
-        HashMap::try_from(bpf.map_mut("BACKEND_PORTS").ok_or(anyhow::anyhow!("Failed to get BACKEND_PORTS"))?)?;
+        HashMap::try_from(bpf.map_mut("BACKEND_PORTS").context("Failed to get BACKEND_PORTS")?)?;
 
     let mut ports: [u16; 4] = [0; 4];
     ports[0] = 9876;


### PR DESCRIPTION
Hi,

I noticed that, when building the project directly from the main repo, the `ok_or` method was producing a different type of error than what is expected by `try_from`. 

Sorry about that.

Testing this approach from a clean run, the run worked.

Let me know if this make sense.

Thanks!